### PR TITLE
Raise node version

### DIFF
--- a/action.yaml
+++ b/action.yaml
@@ -2,7 +2,7 @@ name: 'github-action-todo-commenter'
 description: Parses pull request files based on tags and creates a comment with a task list
 author: Georgios Kampitakis
 runs:
-  using: 'node12'
+  using: 'node16'
   main: 'lib/index.js'
 branding:
   icon: 'check-circle'


### PR DESCRIPTION
Node 12 is deprecated for github actions. The action should use min. the node16 image.

https://github.blog/changelog/2022-09-22-github-actions-all-actions-will-begin-running-on-node16-instead-of-node12/